### PR TITLE
Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ use Data::Dumper;
 
 my $lat  = 43.6667;
 my $long = -79.4167;
+my $time = "1475363709"; # example epoch time (optional)
 my $key = "c9ce1c59d139c3dc62961cbd63097d13"; # example DarkSky.net API key
 
 my $forecast = DarkSky::API->new(
     key       => $key,
     longitude => $long,
     latitude  => $lat,
+    time      => $time
 );
 
 say "current temperature: " . $forecast->{currently}->{temperature};

--- a/lib/DarkSky/API.pm
+++ b/lib/DarkSky/API.pm
@@ -93,11 +93,13 @@ use Data::Dumper;
 my $lat  = 43.6667;
 my $long = -79.4167;
 my $key = "c9ce1c59d139c3dc62961cbd63097d13"; # example DarkSky API key
+my $time = "1475363709"; # example epoch time (optional)
 
 my $forecast = DarkSky::API->new(
     key       => $key,
     longitude => $long,
     latitude  => $lat,
+    time      => $time
 );
 
 say "current temperature: " . $forecast->{currently}->{temperature};

--- a/lib/DarkSky/API.pm
+++ b/lib/DarkSky/API.pm
@@ -30,7 +30,7 @@ has latitude  => ( is => 'ro' );
 has longitude => ( is => 'ro' );
 has 'time'    => ( is => 'ro', default => '' );
 has timezone  => ( is => 'ro' );
-has offset    => ( is => 'ro' );
+has offset    => ( is => 'ro' ); # Deprecated
 has currently => ( is => 'ro' );
 has minutely  => ( is => 'ro' );
 has hourly    => ( is => 'ro' );

--- a/lib/DarkSky/API.pm
+++ b/lib/DarkSky/API.pm
@@ -92,8 +92,8 @@ use Data::Dumper;
 
 my $lat  = 43.6667;
 my $long = -79.4167;
-my $key = "c9ce1c59d139c3dc62961cbd63097d13"; # example DarkSky API key
 my $time = "1475363709"; # example epoch time (optional)
+my $key = "c9ce1c59d139c3dc62961cbd63097d13"; # example DarkSky API key
 
 my $forecast = DarkSky::API->new(
     key       => $key,


### PR DESCRIPTION
Added deprecated note to "offset" response key. Docs advises to no longer use offset citing DST issues. Added time attribute to docs example and used a recent epoch time. Cited that this attribute was optional for the API request. 
