### PR TITLE
mock http requests

### DIFF
--- a/lib/DarkSky/API.pm
+++ b/lib/DarkSky/API.pm
@@ -65,14 +65,7 @@ sub BUILDARGS {
     die "Request to '$url' failed: $response->{status} $response->{reason}\n"
       unless $response->{success};
 
-    my $forecast = decode_json( $response->{content} );
-
-    while ( my ( $key, $val ) = each %args ) {
-        unless ( exists( $forecast->{$key} ) ) {
-            $forecast->{$key} = $val;
-        }
-    }
-    return $forecast;
+    return decode_json( $response->{content} );
 }
 
 1;

--- a/t/darksky.t
+++ b/t/darksky.t
@@ -1,32 +1,37 @@
 use Test::More tests => 6;
 
-use DarkSky::API;
 use strict;
 use warnings;
-use HTTP::Tiny;
+use DarkSky::API;
 use Test::MockModule;
 
 my $lat  = 43.6667;
 my $long = -79.4167;
 my $time = 1373241600;
 
-my $mock = Test::MockModule('HTTP::Tiny');
-$mock->mock(get => sub {
-    return {
-        'latitude' => $lat,
-        'longitude' => $long,
-        'currently' => { 'time' => $time , 'summary' => 'something'},
-        'daily' => {'data' => 1},
-        'hourly' => {'data' => 1},
-    };
-});
+my $forecast;
 
-my $forecast = DarkSky::API->new(
-    key       => 'something',
-    longitude => $long,
-    latitude  => $lat,
-    'time'    => $time
-);
+{
+    my $mock = Test::MockModule->new('DarkSky::API');
+    $mock->mock(
+        "new" => sub {
+            return {
+                'latitude'  => $lat,
+                'longitude' => $long,
+                'currently' => { 'time' => $time, 'summary' => 'something' },
+                'daily'  => { 'data' => 1 },
+                'hourly' => { 'data' => 1 },
+            };
+        }
+    );
+
+    $forecast = DarkSky::API->new(
+        key       => 'something',
+        longitude => $long,
+        latitude  => $lat,
+        'time'    => $time
+    );
+}
 
 is( sprintf( "%.4f", $forecast->{latitude} ),  $lat );
 is( sprintf( "%.4f", $forecast->{longitude} ), $long );

--- a/t/darksky.t
+++ b/t/darksky.t
@@ -1,18 +1,28 @@
 use Test::More tests => 6;
 
 use DarkSky::API;
-use Term::ReadKey;
 use strict;
 use warnings;
+use HTTP::Tiny;
+use Test::MockModule;
 
 my $lat  = 43.6667;
 my $long = -79.4167;
 my $time = 1373241600;
-diag("Please enter your DarkSky API key: ");
-my $key = ReadLine(0);
-chomp $key;
+
+my $mock = Test::MockModule('HTTP::Tiny');
+$mock->mock(get => sub {
+    return {
+        'latitude' => $lat,
+        'longitude' => $long,
+        'currently' => { 'time' => $time , 'summary' => 'something'},
+        'daily' => {'data' => 1},
+        'hourly' => {'data' => 1},
+    };
+});
+
 my $forecast = DarkSky::API->new(
-    key       => $key,
+    key       => 'something',
     longitude => $long,
     latitude  => $lat,
     'time'    => $time


### PR DESCRIPTION
Short circuit http requests. This is cheating: I can't find a way to exactly mock HTTP::Tiny->new->get